### PR TITLE
Added graceful status cleanup

### DIFF
--- a/lib/charms/rolling_ops/v0/rollingops.py
+++ b/lib/charms/rolling_ops/v0/rollingops.py
@@ -88,7 +88,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 
 class LockNoRelationError(Exception):
@@ -374,7 +374,8 @@ class RollingOpsManager(Object):
                 self.charm.on[self.name].run_with_lock.emit()
             return
 
-        self.model.app.status = ActiveStatus()
+        if self.model.app.status.message == f"Beginning rolling {self.name}":
+            self.model.app.status = ActiveStatus()
 
     def _on_acquire_lock(self: CharmBase, event: ActionEvent):
         """Request a lock."""
@@ -408,4 +409,6 @@ class RollingOpsManager(Object):
 
         # cleanup old callback overrides
         relation.data[self.charm.unit].update({"callback_override": ""})
-        self.model.unit.status = ActiveStatus()
+
+        if self.model.unit.status.message == f"Executing {self.name} operation":
+            self.model.unit.status = ActiveStatus()


### PR DESCRIPTION
This PR adds a cleanup of status that only happens when the app / unit status is set by `rollingops`.