### PR TITLE
fix: pass app to re-emitted relation-changed to silence new ops warnings

### DIFF
--- a/lib/charms/rolling_ops/v0/rollingops.py
+++ b/lib/charms/rolling_ops/v0/rollingops.py
@@ -88,7 +88,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 
 class LockNoRelationError(Exception):
@@ -386,7 +386,8 @@ class RollingOpsManager(Object):
 
             # persist callback override for eventual run
             relation.data[self.charm.unit].update({"callback_override": event.callback_override})
-            self.charm.on[self.name].relation_changed.emit(relation)
+            self.charm.on[self.name].relation_changed.emit(relation, app=self.charm.app)
+
         except LockNoRelationError:
             logger.debug("No {} peer relation yet. Delaying rolling op.".format(self.name))
             event.defer()


### PR DESCRIPTION
## Changes Made
#### `fix: pass app to re-emitted relation-changed to silence new ops warnings`
- More recent `ops` versions have checks semi-forcing `relation_event.app` attrs to be present
     - https://github.com/canonical/operator/blob/dc47640f8ea915049d9e20a1fe4ea189c96ae8d1/ops/charm.py#L420
     - https://github.com/canonical/operator/blob/dc47640f8ea915049d9e20a1fe4ea189c96ae8d1/ops/charm.py#L459
- This change ensures `app` is set on the custom `RelationChanged` event during `_on_acquire_lock`, thus silencing the noisy warnings from logs