### PR TITLE
Process defer _run_with_lock

### DIFF
--- a/lib/charms/rolling_ops/v0/rollingops.py
+++ b/lib/charms/rolling_ops/v0/rollingops.py
@@ -327,19 +327,6 @@ class RollingOpsManager(Object):
         Then, if we are the leader, fire off a process locks event.
 
         """
-        if self.name not in os.environ["JUJU_DISPATCH_PATH"]:
-            # Fixes gh#13: there is a chance, e.g. at the start of a deployment, where multiple hooks
-            # from different relations will be happening, all at the same time.
-            # It is also possible, in these situations, that the databag of hooks will differ, depending
-            # on which endpoint is being called. There is no guarantee from Juju it will be consistent
-            # across different hooks in different endpoints.
-            # Therefore, we want to be sure we are only seeing one single type of hook:
-            #       {self.name}-relation-...
-            # That will guarantee consistency across hook calls, and hence, databags.
-            logger.debug(f"Rolling Ops: We cannot call _on_relation_changed outside of the {self.name} hook")
-            event.defer()
-            return
-
         lock = Lock(self)
 
         if lock.is_pending():

--- a/lib/charms/rolling_ops/v0/rollingops.py
+++ b/lib/charms/rolling_ops/v0/rollingops.py
@@ -398,6 +398,7 @@ class RollingOpsManager(Object):
         lock = Lock(self)
         if not lock.is_held():
             logger.warning("Lock not held anymore. Abandon this event and reacquire it.")
+            relation = self.model.get_relation(self.name)
             callback_name = relation.data[self.charm.unit].get(
                 "callback_override", self._callback.__name__
             )


### PR DESCRIPTION
Extends _run_with_lock method to:
* Capture errors from callback() method
* Process deferred action set by the callback()