### PR TITLE
[DPE-3590] Rel Changed Event only runs in its own peer relation hook

### DIFF
--- a/lib/charms/rolling_ops/v0/rollingops.py
+++ b/lib/charms/rolling_ops/v0/rollingops.py
@@ -327,7 +327,6 @@ class RollingOpsManager(Object):
             # Therefore, we want to be sure we are only seeing one single type of hook:
             #       {self.name}-relation-...
             # That will guarantee consistency across hook calls, and hence, databags.
-            logger.warning(f"Abandon {event} as we are executing it outside of {self.name} hook context")
             return
 
         lock = Lock(self)

--- a/lib/charms/rolling_ops/v0/rollingops.py
+++ b/lib/charms/rolling_ops/v0/rollingops.py
@@ -326,6 +326,9 @@ class RollingOpsManager(Object):
         Then, if we are the leader, fire off a process locks event.
 
         """
+        if self.name not in os.environ.get("JUJU_DISPATCH_PATH", ""):
+            return
+
         lock = Lock(self)
 
         if lock.is_pending():


### PR DESCRIPTION
The rolling-ops **MUST** guarantee that its peer relation event is executed within the peer relation hook context, to avoid any data drift between hooks. This PR enforces this behavior. If rolling-ops internal events are called in a different hook context, then we should process it differently.

In essence, any **READ** from the databag must be guaranteed to happen within the peer relation hook. **WRITE** can happen on other hooks. That means changes for all three events that belong to this lib.

This PR also removes the `process-locks` event, as they must be tightly coupled with its peer relation changed. This way, we guarantee the lock is only granted based on the up-to-date information from the peer-relation.

Likewise, we need a safe-guard in the `run-with-lock` event.

One comment in special, I believe we do not need the defer, as Marc pointed out: https://github.com/canonical/charm-rolling-ops/pull/10#discussion_r1493086374.

Closes: #13 