### PR TITLE
[Follow-up] Fix copyright author + Fix matrix data platform channel link

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Penny Gale
+# Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 restart:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Penny Gale
+# Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 name: rolling-ops
@@ -12,7 +12,7 @@ issues: https://github.com/canonical/charm-rolling-ops/issues
 website:
   - https://charmhub.io/rolling-ops
   - https://github.com/canonical/charm-rolling-ops
-  - https://matrix.to/#/#charmhub-data-platform:ubuntu.com
+  - https://matrix.to/#/%23charmhub-data-platform%3Aubuntu.com
   - https://chat.charmhub.io/charmhub/channels/data-platform
 maintainers:
   - Canonical Data Platform <data-platform@lists.launchpad.net>


### PR DESCRIPTION
Follow up to #19, setting Canonical Ltd. as copyright author and fixing matrix data platform channel link that was causing [this issue in release](https://github.com/canonical/charm-rolling-ops/actions/runs/8723667859/job/23933554719#step:8:22). Fix is described [here](https://matrix.to/#/!LhFxJIPEcCacgdMghH:ubuntu.com/$qfqmgYZH_AXqpqVWGCgjt9dBE5S86kRLHgoQyTRkmyI?via=ubuntu.com&via=matrix.org)