### PR TITLE
Improve integration test stability + new tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,7 @@ jobs:
       matrix:
         juju: 
           - snap-channel: 3.4/stable 
+          - snap-channel: 3.1/stable 
           - snap-channel: 2.9/stable
             libjuju: ==2.9.46.1
         cloud: 

--- a/actions.yaml
+++ b/actions.yaml
@@ -10,7 +10,7 @@ restart:
       default: 0
 
 custom-restart:
-  description: "Example restart with a custom callback function. Used in testing"
+  description: Example restart with a custom callback function. Used in testing
   params:
     delay:
       description: "Introduce an artificial delay (for testing)."

--- a/actions.yaml
+++ b/actions.yaml
@@ -10,7 +10,7 @@ restart:
       default: 0
 
 custom-restart:
-  description: Restarts the example service
+  description: "Example restart with a custom callback function. Used in testing"
   params:
     delay:
       description: "Introduce an artificial delay (for testing)."

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,7 +3,7 @@
 
 name: rolling-ops
 display-name: Rolling Ops Library and Example Charm
-summary: Sample charm and re-usable library.,
+summary: Sample charm and re-usable library.
 description: |
   This is a charm containing the Rolling Ops library, along with a sample implementation.
 docs: https://discourse.charmhub.io/t/rolling-ops-example-app-overview/13939
@@ -17,11 +17,6 @@ website:
 maintainers:
   - Canonical Data Platform <data-platform@lists.launchpad.net>
 
-bases:
-  - name: ubuntu
-    channel: focal
-    architectures:
-      - amd64
 peers:
     restart:
         interface: rolling_op

--- a/tests/integration/smoke_test.py
+++ b/tests/integration/smoke_test.py
@@ -72,7 +72,7 @@ async def test_smoke(ops_test: OpsTest):
         # Run the restart, with a delay to alleviate timing issues.
         for unit in app.units:
             logger.info(f"{action_type} - {unit.name}")
-            action: Action = await unit.run_action(action_type, delay=1)
+            action: Action = await unit.run_action(action_type, delay=20)
             await action.wait()
             assert (action.results.get("return-code", None) == 0) or (
                 action.results.get("Code", None) == "0"
@@ -81,7 +81,8 @@ async def test_smoke(ops_test: OpsTest):
         await model.block_until(lambda: app.status in ("maintenance", "error"), timeout=60)
         assert app.status != "error"
 
-        await model.block_until(lambda: app.status in ("error", "blocked", "active"), timeout=60)
+        # await model.block_until(lambda: app.status in ("error", "blocked", "active"), timeout=60)
+        await model.wait_for_idle(status="active", timeout=600)
         assert app.status == "active"
 
         for unit in app.units:

--- a/tests/integration/smoke_test.py
+++ b/tests/integration/smoke_test.py
@@ -137,13 +137,11 @@ async def test_smoke_single_unit(ops_test):
 @pytest.mark.abort_on_fail
 @pytest.mark.group(1)
 async def test_scale_up(ops_test: OpsTest):
-    """Scale the application back up, restart again.
-    """
+    """Scale the application back up, restart again."""
     # to spare the typechecker errors
     assert ops_test.model
     assert ops_test.model_full_name
     model: Model = ops_test.model
-    model_full_name: str = ops_test.model_full_name
 
     # to spare the typechecker errors
     assert model.applications["rolling-ops"]
@@ -159,12 +157,13 @@ async def test_scale_up(ops_test: OpsTest):
     # Run the restart for all units
     for unit in app.units:
         logger.info(f"restart - {unit.name}")
-        action: Action = await unit.run_action("restart", delay=10)
+        await unit.run_action("restart", delay=10)
 
     await model.block_until(lambda: app.status in ("maintenance", "error"), timeout=60)
     assert app.status != "error"
 
     await model.wait_for_idle(status="active", timeout=600)
+
 
 @pytest.mark.abort_on_fail
 @pytest.mark.group(1)
@@ -177,7 +176,6 @@ async def test_on_delete(ops_test: OpsTest):
     assert ops_test.model
     assert ops_test.model_full_name
     model: Model = ops_test.model
-    model_full_name: str = ops_test.model_full_name
 
     # to spare the typechecker errors
     assert model.applications["rolling-ops"]
@@ -187,7 +185,7 @@ async def test_on_delete(ops_test: OpsTest):
     # We don't wait for the restart operation to finish before removing it
     for unit in app.units:
         logger.info(f"restart - {unit.name}")
-        action: Action = await unit.run_action("restart", delay=30)
+        await unit.run_action("restart", delay=30)
 
     await model.block_until(lambda: app.status in ("maintenance", "error"), timeout=60)
     assert app.status != "error"

--- a/tests/integration/smoke_test.py
+++ b/tests/integration/smoke_test.py
@@ -72,7 +72,7 @@ async def test_smoke(ops_test: OpsTest):
         # Run the restart, with a delay to alleviate timing issues.
         for unit in app.units:
             logger.info(f"{action_type} - {unit.name}")
-            action: Action = await unit.run_action(action_type, delay=20)
+            action: Action = await unit.run_action(action_type, delay=10)
             await action.wait()
             assert (action.results.get("return-code", None) == 0) or (
                 action.results.get("Code", None) == "0"
@@ -81,9 +81,7 @@ async def test_smoke(ops_test: OpsTest):
         await model.block_until(lambda: app.status in ("maintenance", "error"), timeout=60)
         assert app.status != "error"
 
-        # await model.block_until(lambda: app.status in ("error", "blocked", "active"), timeout=60)
         await model.wait_for_idle(status="active", timeout=600)
-        assert app.status == "active"
 
         for unit in app.units:
             restart_type = get_restart_type(unit=unit, model_name=model_full_name)
@@ -119,7 +117,7 @@ async def test_smoke_single_unit(ops_test):
     for action_type in ["restart", "custom-restart"]:
         # Run the restart, with a delay to alleviate timing issues.
         logger.info(f"{action_type} - {app.units[0].name}")
-        action: Action = await app.units[0].run_action(action_type, delay=1)
+        action: Action = await app.units[0].run_action(action_type, delay=30)
 
         await model.block_until(lambda: app.status in ("maintenance", "error"), timeout=60)
         assert app.status != "error"
@@ -129,9 +127,69 @@ async def test_smoke_single_unit(ops_test):
             action.results.get("Code", None) == "0"
         )
 
-        await model.block_until(lambda: app.status in ("error", "blocked", "active"), timeout=60)
-        assert app.status == "active"
+        await model.wait_for_idle(status="active", timeout=600)
 
         for unit in app.units:
             restart_type = get_restart_type(unit=unit, model_name=model_full_name)
             assert restart_type == action_type
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.group(1)
+async def test_scale_up(ops_test: OpsTest):
+    """Scale the application back up, restart again.
+    """
+    # to spare the typechecker errors
+    assert ops_test.model
+    assert ops_test.model_full_name
+    model: Model = ops_test.model
+    model_full_name: str = ops_test.model_full_name
+
+    # to spare the typechecker errors
+    assert model.applications["rolling-ops"]
+    app: Application = model.applications["rolling-ops"]
+
+    try:
+        await app.scale(3)
+    except JujuAPIError:  # handling vm vs k8s
+        await app.add_units(2)
+
+    await model.wait_for_idle(status="active", timeout=600)
+
+    # Run the restart for all units
+    for unit in app.units:
+        logger.info(f"restart - {unit.name}")
+        action: Action = await unit.run_action("restart", delay=10)
+
+    await model.block_until(lambda: app.status in ("maintenance", "error"), timeout=60)
+    assert app.status != "error"
+
+    await model.wait_for_idle(status="active", timeout=600)
+
+@pytest.mark.abort_on_fail
+@pytest.mark.group(1)
+async def test_on_delete(ops_test: OpsTest):
+    """Basic restart followed by premature app deletion.
+
+    The lock should not block the application from getting removed completely.
+    """
+    # to spare the typechecker errors
+    assert ops_test.model
+    assert ops_test.model_full_name
+    model: Model = ops_test.model
+    model_full_name: str = ops_test.model_full_name
+
+    # to spare the typechecker errors
+    assert model.applications["rolling-ops"]
+    app: Application = model.applications["rolling-ops"]
+
+    # Run the restart, with a big delay to stall units during the operation.
+    # We don't wait for the restart operation to finish before removing it
+    for unit in app.units:
+        logger.info(f"restart - {unit.name}")
+        action: Action = await unit.run_action("restart", delay=30)
+
+    await model.block_until(lambda: app.status in ("maintenance", "error"), timeout=60)
+    assert app.status != "error"
+
+    await ops_test.model.remove_application("rolling-ops", block_until_done=True)

--- a/tests/integration/smoke_test.py
+++ b/tests/integration/smoke_test.py
@@ -158,7 +158,7 @@ async def test_scale_up(ops_test: OpsTest):
     # Run the restart for all units
     for unit in app.units:
         logger.info(f"restart - {unit.name}")
-        await unit.run_action("restart", delay=10)
+        action: Action = await unit.run_action("restart", delay=10)
         await action.wait()
         assert (action.results.get("return-code", None) == 0) or (
             action.results.get("Code", None) == "0"
@@ -202,7 +202,7 @@ async def test_on_delete(ops_test: OpsTest):
     for unit in app.units:
         logger.info(f"removing unit - {unit.name}")
         await app.destroy_unit(unit.name)
-    
+
     await model.block_until(lambda: len(app.units) == 0, timeout=600)
     assert app.status != "error"
     await ops_test.model.remove_application("rolling-ops", block_until_done=True)


### PR DESCRIPTION
## Changes

- Fixed small typo
- Better description for `custom-restart`
- Removed base
- Stabilization of `smoke_test` (awaits for all units to stabilize before asserting restart type + increased restart delay)
- Addition of 2 new integration tests: scale back up after single unit test, and application removal mid-operation. Feedbacks are welcome!