### PR TITLE
fix: ensure locks cleaned after leader removed

### DIFF
--- a/lib/charms/rolling_ops/v0/rollingops.py
+++ b/lib/charms/rolling_ops/v0/rollingops.py
@@ -88,7 +88,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 class LockNoRelationError(Exception):
@@ -318,6 +318,7 @@ class RollingOpsManager(Object):
         self.framework.observe(charm.on[self.name].acquire_lock, self._on_acquire_lock)
         self.framework.observe(charm.on[self.name].run_with_lock, self._on_run_with_lock)
         self.framework.observe(charm.on[self.name].process_locks, self._on_process_locks)
+        self.framework.observe(charm.on.leader_elected, self._on_process_locks)
 
     def _callback(self: CharmBase, event: EventBase) -> None:
         """Placeholder for the function that actually runs our event.


### PR DESCRIPTION
Addresses **some** of the cases raised in https://github.com/canonical/charm-rolling-ops/issues/22

## Bug Fixes
#### `fix: ensure locks cleaned after leader removed`
- When leader unit is removed, if surviving units requested a lock during the leader unit removal, that leader unit won't be alive to receive `restart-relation-changed` to grant a lock
- A new leader won't be elected until after all `restart-relation-changed` events have expired
- As such, the surviving units will both be stuck in `acquire` state, and be unable to resolve it, resulting in all of them being endlessly `WaitingStatus`
- Fix ensures that when a new leader is elected, it attempts to clean-up pending lock requests