### PR TITLE
Update to use actions/checkout@v4 to address Node16 deprecation warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install tox & poetry
         run: |
           pipx install tox

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
       - build
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Release bumped charm library


### PR DESCRIPTION
## Issue
We have Node16 deprecation warnings due to usage of `actions/checkout@v3` in our CI
See example https://github.com/canonical/charm-rolling-ops/actions/runs/9590105256

## Solution
Update to use `actions/checkout@v4`