### PR TITLE
feat: add deprecation notice

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,25 +1,3 @@
-# ⚠️ Deprecation Notice
-
-This repository is **deprecated** and no longer actively maintained.
-
-- Repository: https://github.com/canonical/charmlibs/tree/main/rollingops
-
-- Documentation: https://documentation.ubuntu.com/charmlibs/reference/charmlibs/rollingops/
-
-- No new features will be added here.
-- This repository may be archived in the future.
-
-If you are starting a new project, **do not use this library**.
-
-### Why?
-
-The Rolling Ops library has been reimplemented to:
-- Support deferrals and retries
-- Fix callback handling: multiple requests are now queued, not overwritten
-- Enable rolling operations across multiple applications (using etcd)
-
-The new version is **not fully backward compatible**, so migration may be required.
-
 # charm-rolling-ops (DEPRECATED)
 
 ## Developing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,26 @@
-# charm-rolling-ops
+# ⚠️ Deprecation Notice
+
+This repository is **deprecated** and no longer actively maintained.
+
+- Repository: https://github.com/canonical/charmlibs/tree/main/rollingops
+
+- Documentation: https://documentation.ubuntu.com/charmlibs/reference/charmlibs/rollingops/
+
+- No new features will be added here.
+- This repository may be archived in the future.
+
+If you are starting a new project, **do not use this library**.
+
+### Why?
+
+The Rolling Ops library has been reimplemented to:
+- Support deferrals and retries
+- Fix callback handling: multiple requests are now queued, not overwritten
+- Enable rolling operations across multiple applications (using etcd)
+
+The new version is **not fully backward compatible**, so migration may be required.
+
+# charm-rolling-ops (DEPRECATED)
 
 ## Developing
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,35 @@
-# rolling-ops
+# ⚠️ Deprecation Notice
+
+This repository is **deprecated** and is no longer actively maintained.
+
+- No new features will be added
+- This repository may be archived in the future
+
+If you are starting a new project, **do not use this library**.
+
+Please use the new implementation instead:
+
+- Repository: https://github.com/canonical/charmlibs/tree/main/rollingops
+- Documentation: https://documentation.ubuntu.com/charmlibs/reference/charmlibs/rollingops/
+
+### Why?
+
+The Rolling Ops library has been reimplemented to address limitations in the previous version:
+
+- Deferred callbacks could break mutual exclusion, causing operations to run without a lock
+- Multiple lock requests could overwrite each other, silently dropping operations
+- Lack of retry semantics made failure handling unclear and error-prone
+
+The new version introduces:
+
+- Safe handling of deferred callbacks, preserving lock guarantees
+- A per-unit operation queue, ensuring all requests are preserved and executed
+- Explicit retry semantics, allowing controlled and predictable failure handling
+- Support for rolling operations across multiple applications (via etcd)
+
+The new version is **not fully backward compatible**, so migration is be required.
+
+# rolling-ops (DEPRECATED)
 [![Tests](https://github.com/canonical/charm-rolling-ops/actions/workflows/ci.yaml/badge.svg)](https://github.com/canonical/charm-rolling-ops/actions/workflows/ci.yaml)
 
 ## Overview

--- a/lib/charms/rolling_ops/v0/rollingops.py
+++ b/lib/charms/rolling_ops/v0/rollingops.py
@@ -89,7 +89,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 
 class LockNoRelationError(Exception):
@@ -301,6 +301,11 @@ class RollingOpsManager(Object):
             callback: a closure to run when we have a lock. (It must take a CharmBase object and
                 EventBase object as args.)
         """
+        logger.warning(
+            "The 'rollingops' v0 library is deprecated and no longer maintained. "
+            "Please migrate to the new implementation: "
+            "https://github.com/canonical/charmlibs/tree/main/rollingops"
+        )
         # "Inherit" from the charm's class. This gives us access to the framework as
         # self.framework, as well as the self.model shortcut.
         super().__init__(charm, None)

--- a/lib/charms/rolling_ops/v1/rollingops.py
+++ b/lib/charms/rolling_ops/v1/rollingops.py
@@ -176,7 +176,7 @@ logger = logging.getLogger(__name__)
 LIBID = "20b7777f58fe421e9a223aefc2b4d3a4"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 1
+LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
@@ -674,6 +674,11 @@ class RollingOpsManagerV1(Object):
             relation_name: the peer relation name from metadata.yaml.
             callback_targets: mapping from callback_id -> callable.
         """
+        logger.warning(
+            "The 'rollingops' v1 library is deprecated and no longer maintained. "
+            "Please migrate to the new implementation: "
+            "https://github.com/canonical/charmlibs/tree/main/rollingops"
+        )
         super().__init__(charm, "rolling-ops-manager")
         self._charm = charm
         self.relation_name = relation_name


### PR DESCRIPTION
The new implementation for rollingops library was added  [here](https://github.com/canonical/charmlibs/pull/447)

This PR adds the deprecation notice so that new implementations privilege the new version.